### PR TITLE
Add extension to use with IntelliJ to create links in PlantUML diagrams

### DIFF
--- a/.asciidoctor/lib/link-in-puml-macro.rb
+++ b/.asciidoctor/lib/link-in-puml-macro.rb
@@ -1,0 +1,5 @@
+RUBY_ENGINE == 'opal' ? (require 'link-in-puml-macro/extension') : (require_relative 'link-in-puml-macro/extension')
+
+Extensions.register do
+  inline_macro LinkInPumlMacro
+end

--- a/.asciidoctor/lib/link-in-puml-macro/extension.rb
+++ b/.asciidoctor/lib/link-in-puml-macro/extension.rb
@@ -1,0 +1,25 @@
+require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
+
+include ::Asciidoctor
+
+class LinkInPumlMacro < Extensions::InlineMacroProcessor
+  use_dsl
+  named :'link-in-puml'
+
+  def process parent, target, attrs
+
+    anchor = parent.apply_subs("xref:#{target}[]", [:macros])
+
+    # parse the anchor
+    matches = anchor.match(%r{^<a href="(?<href>.+?)"[^>]*>(?<text>.*)</a>$})
+
+    if matches
+      # matched, output the href
+      create_inline(parent, :quoted, matches[:href])
+    else
+      # no match, output the target as-is
+      create_inline(parent, :quoted, target)
+    end
+
+  end
+end


### PR DESCRIPTION
This made it work for me both in IntelliJ with a local rendering of diagrams and with Kroki.

Usually I use macro names without dashes, so I would opt for using `linkinpuml` instead of `link-in-puml`. 